### PR TITLE
Allow skipping migrations with option recorded in Migrations table

### DIFF
--- a/src/Temelie.Database.Providers.MySql/Providers/MySql/DatabaseProvider.Script.cs
+++ b/src/Temelie.Database.Providers.MySql/Providers/MySql/DatabaseProvider.Script.cs
@@ -193,7 +193,26 @@ public partial class DatabaseProvider
 
     public override IDatabaseObjectScript GetColumnScript(ColumnModel column)
     {
-        return null;
+        if (string.IsNullOrEmpty(column.ColumnName) || string.IsNullOrEmpty(column.TableName))
+        {
+            return null;
+        }
+
+        string generateDropScript()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"ALTER TABLE {QuoteCharacterStart}{column.TableName}{QuoteCharacterEnd} DROP COLUMN {QuoteCharacterStart}{column.ColumnName}{QuoteCharacterEnd}");
+            return sb.ToString();
+        }
+
+        string generateCreateScript()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"ALTER TABLE {QuoteCharacterStart}{column.TableName}{QuoteCharacterEnd} ADD COLUMN {GetScript(column)}");
+            return sb.ToString();
+        }
+
+        return new DatabaseObjectScript(generateCreateScript, generateDropScript);
     }
 
     private string GetScript(ColumnModel columnModel)

--- a/src/Temelie.Database.Services/Services/IScriptService.cs
+++ b/src/Temelie.Database.Services/Services/IScriptService.cs
@@ -5,7 +5,7 @@ namespace Temelie.Database.Services;
 public interface IScriptService
 {
     void CreateScripts(ConnectionStringModel connectionString, DirectoryInfo directory, IProgress<ScriptProgress> progress, string objectFilter = "", IDatabaseProvider createScriptsProvider = null);
-    void ExecuteScripts(ConnectionStringModel connectionString, DirectoryInfo directory, IProgress<ScriptProgress> progress, bool continueOnError = true);
+    void ExecuteScripts(ConnectionStringModel connectionString, DirectoryInfo directory, IProgress<ScriptProgress> progress, bool continueOnError = true, bool skipMigrations = false);
     string MergeScripts(IEnumerable<string> scripts);
     void MergeScripts(IEnumerable<string> scripts, string toFile);
 }


### PR DESCRIPTION
This PR adds the options to skip migrations for certain tables. In the case when the caller chooses to skip migrations, individual migrations will still be added to the Migrations table with a value of 1 for the newly-created Skipped column.